### PR TITLE
Update cli.js to include missing Text import

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -140,6 +140,10 @@ const summary = [
 	'',
 	`4. Use Tailwind`,
 	'',
+	` ${chalk.red('import')} {${chalk.green('Text')}} ${chalk.red(
+		'from'
+	)} ${chalk.yellow("'react-native'")};`,
+	'',
 	` ${chalk.red('import')} {${chalk.green('useTailwind')}} ${chalk.red(
 		'from'
 	)} ${chalk.yellow("'tailwind-rn'")};`,


### PR DESCRIPTION
During setup, I noticed that the `<Text/>` component import was missing from step (4) "Use Tailwind"--added the import.  I am not sure if you were going for completeness in step 4, so feel free to ignore this if you want.